### PR TITLE
wip: implement full bot system, inactivity handling and leave API

### DIFF
--- a/src/main/java/at/aau/serg/scotlandyard/bot/BotDetective.java
+++ b/src/main/java/at/aau/serg/scotlandyard/bot/BotDetective.java
@@ -1,0 +1,16 @@
+package at.aau.serg.scotlandyard.bot;
+
+import at.aau.serg.scotlandyard.gamelogic.player.Detective;
+import at.aau.serg.scotlandyard.gamelogic.player.tickets.PlayerTickets;
+
+public class BotDetective extends Detective {
+
+    public BotDetective(String name, int startPos, PlayerTickets tickets) {
+        super(name, startPos, tickets);
+    }
+
+    @Override
+    public boolean isBot() {
+        return true;
+    }
+}

--- a/src/main/java/at/aau/serg/scotlandyard/bot/BotFactory.java
+++ b/src/main/java/at/aau/serg/scotlandyard/bot/BotFactory.java
@@ -1,0 +1,24 @@
+package at.aau.serg.scotlandyard.bot;
+
+import at.aau.serg.scotlandyard.gamelogic.player.*;
+import at.aau.serg.scotlandyard.gamelogic.player.tickets.PlayerTickets;
+
+public class BotFactory {
+
+    public static Player createBotReplacement(Player original) {
+        String name = original.getName();
+        if (!name.startsWith("[BOT] ")) {
+            name = "[BOT] " + name;
+        }
+
+        int pos = original.getPosition();
+        PlayerTickets tickets = original.getTickets().copy(); //aktuelle tickets kopieren
+
+        if (original instanceof MrX) {
+            return new BotPlayer(name, pos, tickets);
+        } else if (original instanceof Detective) {
+            return new BotDetective(name, pos, tickets);
+        }
+        return null;
+    }
+}

--- a/src/main/java/at/aau/serg/scotlandyard/bot/BotLogic.java
+++ b/src/main/java/at/aau/serg/scotlandyard/bot/BotLogic.java
@@ -1,0 +1,26 @@
+package at.aau.serg.scotlandyard.bot;
+
+import at.aau.serg.scotlandyard.gamelogic.GameState;
+import at.aau.serg.scotlandyard.gamelogic.player.Player;
+import at.aau.serg.scotlandyard.gamelogic.player.tickets.Ticket;
+
+import java.util.List;
+import java.util.Map;
+
+public class BotLogic {
+    public static Map.Entry<Integer, Ticket> decideMove(String playerName, GameState gameState) {
+        List<Map.Entry<Integer, Ticket>> moves = gameState.getAllowedMoves(playerName);
+        return moves.isEmpty() ? null : moves.get(0);
+    }
+
+
+    public static void executeBotMove(Player bot, GameState gameState) {
+        var move = decideMove(bot.getName(), gameState);
+        if (move != null) {
+            gameState.movePlayer(bot.getName(), move.getKey(), move.getValue());
+        } else {
+            gameState.cantMove(gameState.getGameId());
+        }
+    }
+
+}

--- a/src/main/java/at/aau/serg/scotlandyard/bot/BotPlayer.java
+++ b/src/main/java/at/aau/serg/scotlandyard/bot/BotPlayer.java
@@ -1,0 +1,11 @@
+package at.aau.serg.scotlandyard.bot;
+
+import at.aau.serg.scotlandyard.gamelogic.player.MrX;
+import at.aau.serg.scotlandyard.gamelogic.player.tickets.PlayerTickets;
+
+public class BotPlayer extends MrX {
+
+    public BotPlayer(String name, int startPos, PlayerTickets tickets) {
+        super(name, startPos, tickets);
+    }
+}

--- a/src/main/java/at/aau/serg/scotlandyard/controller/GameController.java
+++ b/src/main/java/at/aau/serg/scotlandyard/controller/GameController.java
@@ -1,6 +1,7 @@
 package at.aau.serg.scotlandyard.controller;
 
 import at.aau.serg.scotlandyard.dto.GameOverviewDTO;
+import at.aau.serg.scotlandyard.dto.LeaveGameRequest;
 import at.aau.serg.scotlandyard.gamelogic.GameManager;
 import at.aau.serg.scotlandyard.gamelogic.GameState;
 import at.aau.serg.scotlandyard.gamelogic.MrXDoubleMove;
@@ -267,5 +268,18 @@ public class GameController {
             default:
                 return "Spiel läuft noch.";
         }
+    }
+    @PostMapping("/{gameId}/leave")
+    public ResponseEntity<Void> leaveGame(
+            @PathVariable String gameId,
+            @RequestBody LeaveGameRequest req) {
+
+        GameState game = gameManager.getGame(gameId);
+        if (game == null) {
+            return ResponseEntity.notFound().build();
+        }
+
+        game.replaceWithBot(req.getPlayerId());
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/at/aau/serg/scotlandyard/dto/LeaveGameRequest.java
+++ b/src/main/java/at/aau/serg/scotlandyard/dto/LeaveGameRequest.java
@@ -1,0 +1,31 @@
+package at.aau.serg.scotlandyard.dto;
+
+public class LeaveGameRequest {
+    private String gameId;
+    private String playerId;
+
+    public LeaveGameRequest() {
+
+    }
+
+    public LeaveGameRequest(String gameId, String playerId) {
+        this.gameId = gameId;
+        this.playerId = playerId;
+    }
+
+    public String getGameId() {
+        return gameId;
+    }
+
+    public void setGameId(String gameId) {
+        this.gameId = gameId;
+    }
+
+    public String getPlayerId() {
+        return playerId;
+    }
+
+    public void setPlayerId(String playerId) {
+        this.playerId = playerId;
+    }
+}

--- a/src/main/java/at/aau/serg/scotlandyard/gamelogic/GameManager.java
+++ b/src/main/java/at/aau/serg/scotlandyard/gamelogic/GameManager.java
@@ -11,7 +11,7 @@ import java.util.Set;
 @Component
 public class GameManager {
 
-    private final Map<String, GameState> games = new HashMap<>();
+    private static final Map<String, GameState> games = new HashMap<>();
     private final SimpMessagingTemplate messaging;
 
     @Autowired
@@ -27,11 +27,19 @@ public class GameManager {
         return games.get(gameId);
     }
 
-    public void removeGame(String gameId) {
+    public static void removeGame(String gameId) {
         games.remove(gameId);
     }
 
     public Set<String> getAllGameIds() {
         return games.keySet();
     }
+
+    public void updateLastActivity(String gameId, String playerId) {
+        GameState game = games.get(gameId);
+        if (game != null) {
+            game.updateLastActivity(playerId);
+        }
+    }
+
 }

--- a/src/main/java/at/aau/serg/scotlandyard/gamelogic/GameState.java
+++ b/src/main/java/at/aau/serg/scotlandyard/gamelogic/GameState.java
@@ -1,6 +1,7 @@
 package at.aau.serg.scotlandyard.gamelogic;
 
 
+import at.aau.serg.scotlandyard.bot.BotFactory;
 import at.aau.serg.scotlandyard.dto.GameMapper;
 
 import at.aau.serg.scotlandyard.gamelogic.board.Board;
@@ -9,10 +10,13 @@ import at.aau.serg.scotlandyard.gamelogic.player.Detective;
 import at.aau.serg.scotlandyard.gamelogic.player.MrX;
 import at.aau.serg.scotlandyard.gamelogic.player.Player;
 import at.aau.serg.scotlandyard.gamelogic.player.tickets.Ticket;
+import at.aau.serg.scotlandyard.bot.BotLogic;
+
 
 import lombok.Getter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 import java.util.*;
@@ -30,6 +34,10 @@ public class GameState {
     private static final Logger logger = LoggerFactory.getLogger(GameState.class);
 
     Map<String, Integer> playerPositions = new HashMap<>();
+    private final Map<String, Long> lastActivityMap = new HashMap<>();
+    @Autowired
+    private GameManager gameManager;
+
 
 
 
@@ -42,6 +50,7 @@ public class GameState {
 
     public void initRoundManager(List<Detective>detectives, MrX mrX){ //nicht ideal
         this.roundManager = new RoundManager(detectives, mrX);
+        this.roundManager.setGameState(this);
     }
 
     public void cantMove(String gameId) {
@@ -207,6 +216,9 @@ public class GameState {
         return roundManager.getCurrentPlayer().getName();
     }
 
+    public String getGameId() {
+        return  gameId;
+    }
 
 
     //Winning Condition
@@ -264,8 +276,6 @@ public class GameState {
                             winner,
                             Ticket.DOUBLE,
                             players
-
-
 
                     )
             );
@@ -384,6 +394,71 @@ public class GameState {
         return history;
     }
 
+
+    public void updateLastActivity(String playerId) {
+        lastActivityMap.put(playerId, System.currentTimeMillis());
+    }
+
+    public Map<String, Long> getLastActivityMap() {
+        return new HashMap<>(lastActivityMap);
+    }
+
+    public Player replaceWithBot(String playerName) {
+        Player original = players.get(playerName);
+        if (original == null) return null;
+
+        // Wenn MrX geht, Spiel abbrechen (nicht durch Bot ersetzen)
+        if (original.isMrX()) {
+            messaging.convertAndSend("/topic/game/" + gameId + "/system", "mrX");
+
+            // Spiel sofort löschen, weil MrX weg ist
+            gameManager.removeGame(gameId);
+
+            System.out.println("MrX hat das Spiel verlassen – Game " + gameId + " wurde entfernt.");
+            return null;
+        }
+
+
+        // Bot erzeugen und Spieler ersetzen
+        Player bot = BotFactory.createBotReplacement(original);
+        if (bot != null) {
+            players.remove(original.getName());
+            playerPositions.remove(original.getName());
+            players.put(bot.getName(), bot);
+
+            if (roundManager != null) {
+                roundManager.replacePlayer(original, bot);
+            }
+
+            messaging.convertAndSend(
+                    "/topic/game/" + gameId + "/system",
+                    "🤖 Spieler '" + original.getName() + "' wurde durch den Bot '" + bot.getName() + "' ersetzt."
+            );
+
+            // Bot sofort handeln lassen, falls er am Zug ist
+            if (bot.getName().equals(getCurrentPlayerName())) {
+                var move = BotLogic.decideMove(bot.getName(), this);
+                if (move != null) {
+                    movePlayer(bot.getName(), move.getKey(), move.getValue());
+                } else {
+                    cantMove(gameId);
+                }
+            }
+
+            if (onlyBotsLeft()) {
+                gameManager.removeGame(gameId);
+            }
+
+
+            return bot;
+        }
+
+        return null;
+    }
+
+    public boolean onlyBotsLeft() {
+        return players.values().stream().allMatch(Player::isBot);
+    }
 
 }
 

--- a/src/main/java/at/aau/serg/scotlandyard/gamelogic/player/Detective.java
+++ b/src/main/java/at/aau/serg/scotlandyard/gamelogic/player/Detective.java
@@ -13,6 +13,12 @@ public class Detective extends Player {
 
     }
 
+    //für bots
+    public Detective(String name, int startPos, PlayerTickets tickets) {
+        super(name, tickets);
+        this.setPos(startPos);
+    }
+
     private static PlayerTickets initializeTickets() {
         Map<Ticket, Integer> initialTickets = new EnumMap<>(Ticket.class);
         initialTickets.put(Ticket.TAXI, 10);

--- a/src/main/java/at/aau/serg/scotlandyard/gamelogic/player/MrX.java
+++ b/src/main/java/at/aau/serg/scotlandyard/gamelogic/player/MrX.java
@@ -17,6 +17,11 @@ public class MrX extends Player {
         super(name, initializeTickets());
     }
 
+    public MrX(String name, int startPos, PlayerTickets tickets) {
+        super(name, tickets);
+        this.setPos(startPos);
+    }
+
     private static PlayerTickets initializeTickets() {
         Map<Ticket, Integer> initialTickets = new EnumMap<>(Ticket.class);
 

--- a/src/main/java/at/aau/serg/scotlandyard/gamelogic/player/Player.java
+++ b/src/main/java/at/aau/serg/scotlandyard/gamelogic/player/Player.java
@@ -72,4 +72,13 @@ public abstract class Player {
     public void setPos(int pos) {
         this.pos = pos;
     }
+
+    public boolean isMrX() {
+        return this instanceof MrX;
+    }
+
+    public boolean isBot() {
+        return false; // Standardmäßig: kein Bot
+    }
+
 }

--- a/src/main/java/at/aau/serg/scotlandyard/gamelogic/player/tickets/PlayerTickets.java
+++ b/src/main/java/at/aau/serg/scotlandyard/gamelogic/player/tickets/PlayerTickets.java
@@ -43,6 +43,10 @@ public class PlayerTickets {
         return Map.copyOf(tickets); // unveränderlich
     }
 
+    public PlayerTickets copy() {
+        return new PlayerTickets(new EnumMap<>(this.tickets));
+    }
+
 }
 
 

--- a/src/main/java/at/aau/serg/scotlandyard/websocket/GameInactivityMonitor.java
+++ b/src/main/java/at/aau/serg/scotlandyard/websocket/GameInactivityMonitor.java
@@ -1,0 +1,78 @@
+package at.aau.serg.scotlandyard.websocket;
+
+import at.aau.serg.scotlandyard.bot.BotLogic;
+import at.aau.serg.scotlandyard.gamelogic.GameManager;
+import at.aau.serg.scotlandyard.gamelogic.GameState;
+import at.aau.serg.scotlandyard.bot.BotPlayer;
+import at.aau.serg.scotlandyard.gamelogic.player.Player;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class GameInactivityMonitor {
+
+    private final GameManager gameManager;
+    private final SimpMessagingTemplate messaging;
+
+    public GameInactivityMonitor(GameManager gameManager, SimpMessagingTemplate messaging) {
+        this.gameManager = gameManager;
+        this.messaging = messaging;
+    }
+
+    @Scheduled(fixedRate = 60_000) // alle 60 Sekunden
+    public void checkInactivePlayersInGame() {
+        long now = System.currentTimeMillis();
+        long timeoutMillis = 4 * 60 * 1000;
+
+        for (String gameId : gameManager.getAllGameIds()) {
+            GameState game = gameManager.getGame(gameId);
+            if (game == null) continue;
+
+            List<String> inactivePlayers = new ArrayList<>();
+
+            for (Map.Entry<String, Long> entry : game.getLastActivityMap().entrySet()) {
+                String player = entry.getKey();
+                long lastActive = entry.getValue();
+                if (now - lastActive > timeoutMillis) {
+                    inactivePlayers.add(player);
+                }
+            }
+
+            for (String player : inactivePlayers) {
+                System.out.println("⚠️ Spieler im Spiel inaktiv: " + player + " in Game " + gameId);
+
+                Player bot = game.replaceWithBot(player);
+
+
+                if (bot == null) {
+                    sendSystemMessage(gameId, player + " hat das Spiel verlassen.");
+                    continue;
+                }
+
+
+                sendSystemMessage(gameId, player + " wurde durch einen Bot ersetzt.");
+
+
+                if (game.getCurrentPlayerName().equals(bot.getName())) {
+                    var move = BotLogic.decideMove(bot.getName(), game);
+                    if (move != null) {
+                        game.movePlayer(bot.getName(), move.getKey(), move.getValue());
+                    } else {
+                        game.cantMove(gameId);
+                    }
+                }
+
+            }
+
+        }
+    }
+
+    private void sendSystemMessage(String gameId, String message) {
+        messaging.convertAndSend("/topic/game/" + gameId + "/system", message);
+    }
+}

--- a/src/main/java/at/aau/serg/scotlandyard/websocket/GameSocketController.java
+++ b/src/main/java/at/aau/serg/scotlandyard/websocket/GameSocketController.java
@@ -1,5 +1,7 @@
 package at.aau.serg.scotlandyard.websocket;
 
+
+
 import at.aau.serg.scotlandyard.gamelogic.GameManager;
 import at.aau.serg.scotlandyard.gamelogic.GameState;
 import at.aau.serg.scotlandyard.gamelogic.player.tickets.Ticket;
@@ -21,6 +23,39 @@ public class GameSocketController {
         this.gameManager = gameManager;
         this.messaging = messaging;
     }
+
+    @MessageMapping("/game/ping")
+    public void handleGamePing(Map<String, String> payload) {
+        String gameId = payload.get("gameId");
+        String playerId = payload.get("playerId");
+
+        GameState game = gameManager.getGame(gameId);
+        if (game != null) {
+            game.updateLastActivity(playerId);
+            System.out.println("→ [GAME]]Ping erhalten im Spiel von " + playerId);
+        }
+    }
+
+    @MessageMapping("/game/leave")
+    public void handleGameLeave(Map<String, String> payload) {
+        String gameId = payload.get("gameId");
+        String playerId = payload.get("playerId");
+
+        System.out.println("Game leave received: " + gameId + ", " + playerId);
+
+        GameState game = gameManager.getGame(gameId);
+        if (game != null) {
+            game.replaceWithBot(playerId);
+            System.out.println("Spieler ersetzt durch Bot: " + playerId);
+        }
+    }
+
+
+
+
+
+
+
 
 
     @MessageMapping("/game/allowedMoves")

--- a/src/main/java/at/aau/serg/scotlandyard/websocket/LobbyInactivityMonitor.java
+++ b/src/main/java/at/aau/serg/scotlandyard/websocket/LobbyInactivityMonitor.java
@@ -10,12 +10,12 @@ import org.springframework.stereotype.Component;
 import java.util.*;
 
 @Component
-public class InactivityMonitor {
+public class LobbyInactivityMonitor {
 
     private final LobbyManager lobbyManager;
     private final SimpMessagingTemplate messaging;
 
-    public InactivityMonitor(LobbyManager lobbyManager, SimpMessagingTemplate messaging) {
+    public LobbyInactivityMonitor(LobbyManager lobbyManager, SimpMessagingTemplate messaging) {
         this.lobbyManager = lobbyManager;
         this.messaging = messaging;
     }

--- a/src/main/java/at/aau/serg/scotlandyard/websocket/LobbySocketController.java
+++ b/src/main/java/at/aau/serg/scotlandyard/websocket/LobbySocketController.java
@@ -177,6 +177,7 @@ public class LobbySocketController {
     public void handleLeave(@Payload LeaveRequest request) {
         String gameId = request.getGameId();
         String playerId = request.getPlayerId();
+        System.out.println("Game leave received: " + gameId + ", " + playerId);
 
         Lobby lobby = lobbyManager.getLobby(gameId);
         if (lobby != null) {
@@ -193,7 +194,7 @@ public class LobbySocketController {
         Lobby lobby = lobbyManager.getLobby(gameId);
         if (lobby != null) {
             lobby.updateLastActivity(playerId);
-            System.out.println("→ Ping erhalten von " + playerId);
+            System.out.println("→ [LOBBY]Ping erhalten von " + playerId);
         }
     }
 


### PR DESCRIPTION
- create full bot system
- GameState: add replaceWithBot logic for inactive players
  - replace inactive players with bots (except MrX)
  - auto-move if bot is current player
  - detect if only bots remain → remove game
- handle special case when MrX leaves: send system message and remove game
- add scheduled task (GameInactivityMonitor) to detect inactive players every 60s
- GameController: integrate inactivity and bot system in move flow
- new REST endpoint: /leaveGame (explicit player exit support)